### PR TITLE
CE-13006 HAProxy must limit access to the statistics feature

### DIFF
--- a/resources/config_defaults.rb
+++ b/resources/config_defaults.rb
@@ -3,7 +3,6 @@ property :log, String, default: 'global'
 property :mode, String, default: 'http', equal_to: %w(http tcp)
 property :balance, default: 'roundrobin', equal_to: %w(roundrobin static-rr leastconn first source uri url_param header rdp-cookie)
 property :option, Array, default: %w(httplog dontlognull redispatch tcplog)
-property :stats, Hash, default: { 'uri' => '/haproxy-status' }
 property :maxconn, Integer
 property :extra_options, Hash
 property :haproxy_retries, Integer
@@ -31,7 +30,6 @@ action :create do
       variables['defaults']['option'] ||= []
       (variables['defaults']['option'] << new_resource.option).flatten!
       variables['defaults']['stats'] ||= {}
-      variables['defaults']['stats'].merge!(new_resource.stats)
       variables['defaults']['maxconn'] ||= '' unless new_resource.maxconn.nil?
       variables['defaults']['maxconn'] << new_resource.maxconn.to_s unless new_resource.maxconn.nil?
       variables['defaults']['retries'] ||= '' unless new_resource.haproxy_retries.nil?


### PR DESCRIPTION
## JIRA

* https://coupadev.atlassian.net/browse/CE-13066

## Code reviewers

- [ ] pallav-jakhotiya 
- [ ] Ramesh7 
- [ ] cprithvi 

## Summary of issue
Remove the stats page from HAProxy which is open to everybody right now.

## Summary of change
 
Removed the stats page for haproxy-status


## Testing approach

- [x] Manual test
- [ ] No test (please specify why)

## Generated Reviewers

### Ops Cookbook Review (ops_cookbook)

- [ ] @alokdnb
  - This rule is always triggered