### PR TITLE
CE-13009 : Adding custom support for error page

### DIFF
--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -108,6 +108,10 @@ defaults
 <% value.each do | array_element | %>
   <%= option %> <%= array_element %>
 <% end -%>
+<% elsif value.is_a?(Hash) %>
+<% value.each do | key, value | %>
+  <%= option %> <%= key %> <%= value %>
+<% end -%>
 <% else %>
   <%= option %> <%= value %>
 <% end -%>


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CE-13009)

## Summary of issue

**CIS HAProxy Rule:** HAProxy must provide default error files.
**Description:** Information needed by an attacker to begin looking for possible vulnerabilities in a web server includes any information about the web server, backend systems being accessed, and plug-ins or modules being used. Web servers will often display error messages to client users displaying enough information to aid in the debugging of the error. The information given back in error messages may display the web server type, version, patches installed, plug-ins and modules installed, type of code being used by the hosted application, and any backends being used for data storage. This information could be used by an attacker to blueprint what type of attacks might be successful. The information given to users must be minimized to not aid in the blueprinting of the web server.

## Summary of change

Adding error codes & corresponding files: https://github.com/coupa-ops/coupa-lb/pull/217

## Testing approach

Testing details are mentioned in the ticket.